### PR TITLE
Fix to work with latest Hugo

### DIFF
--- a/content/post/lightslider_example.md
+++ b/content/post/lightslider_example.md
@@ -7,14 +7,14 @@ author: pcdummy
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 
-{{% lightslider name="lightslider_example_slider1" url="data/post/lightslider_example.json" includejs="true" %}}
+{{< lightslider name="lightslider_example_slider1" url="data/post/lightslider_example.json" includejs="true" >}}
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 
-{{% lightslider name="lightslider_example_slider2" url="data/post/lightslider_example.json" %}}
+{{< lightslider name="lightslider_example_slider2" url="data/post/lightslider_example.json" >}}
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 
-{{% lightslider name="lightslider_example_slider3" url="data/post/lightslider_example.json" %}}
+{{< lightslider name="lightslider_example_slider3" url="data/post/lightslider_example.json" >}}
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,17 +8,17 @@
     <title>{{ .Title }} &middot; {{ .Site.Title }}</title>
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Oxygen:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/pure-min.css">
-    {{ `<!--[if lte IE 8]><link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-old-ie-min.css"><![endif]-->` | safeHtml }}
-    {{ `<!--[if gt IE 8]><!--><link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-min.css"><!--<![endif]-->` | safeHtml }}
+    {{ `<!--[if lte IE 8]><link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-old-ie-min.css"><![endif]-->` | safeHTML }}
+    {{ `<!--[if gt IE 8]><!--><link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-min.css"><!--<![endif]-->` | safeHTML }}
 
-    {{ `<!--[if lte IE 8]><link rel="stylesheet" href="/css/layouts/blog-old-ie.css"><![endif]-->` | safeHtml }}
-    {{ `<!--[if gt IE 8]><!--><link rel="stylesheet" href="/css/blog.css"><!--<![endif]-->` | safeHtml }}
+    {{ `<!--[if lte IE 8]><link rel="stylesheet" href="/css/layouts/blog-old-ie.css"><![endif]-->` | safeHTML }}
+    {{ `<!--[if gt IE 8]><!--><link rel="stylesheet" href="/css/blog.css"><!--<![endif]-->` | safeHTML }}
 
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
 
     <!-- start hugo lightslider -->
-    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseUrl }}/css/lightGallery.css" />
-    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseUrl }}/css/lightSlider.css" />
+    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/lightGallery.css" />
+    <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/lightSlider.css" />
     <!-- end hugo lightslider -->
 </head>
 <body>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,0 +1,23 @@
+<div class="sidebar pure-u-1 pure-u-md-1-4">
+    <div class="header">
+        <hgroup>
+            <h1 class="brand-title"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
+            <h2 class="brand-tagline">{{ with .Site.Params.Description }} {{.}} {{end}}</h2>
+        </hgroup>
+
+        <nav class="nav">
+            <ul class="nav-list">
+                {{ with .Site.Params.twitter }}
+                <li class="nav-item">
+                    <a class="pure-button" href="http://twitter.com/{{ . }}"><i class="fa fa-twitter"></i> Twitter</a>
+                </li>
+                {{ end }}
+                {{ with .Site.Params.github }}
+                <li class="nav-item">
+                    <a class="pure-button" href="http://github.com/{{ . }} "><i class="fa fa-github-alt"></i> github</a>
+                </li>
+                {{ end }}
+            </ul>
+        </nav>
+    </div>
+</div>

--- a/layouts/shortcodes/lightslider.html
+++ b/layouts/shortcodes/lightslider.html
@@ -19,9 +19,9 @@ Example: {{/*
 */}}
 -->
 {{ if $.Get "includejs" }}
-        <script src="{{ $.Page.Site.BaseUrl }}/js/jquery.min.js"></script>
-        <script src="{{ $.Page.Site.BaseUrl }}/js/lightGallery.min.js"></script>
-        <script src="{{ $.Page.Site.BaseUrl }}/js/jquery.lightSlider.min.js"></script>
+        <script src="{{ $.Page.Site.BaseURL }}/js/jquery.min.js"></script>
+        <script src="{{ $.Page.Site.BaseURL }}/js/lightGallery.min.js"></script>
+        <script src="{{ $.Page.Site.BaseURL }}/js/jquery.lightSlider.min.js"></script>
 {{ end }}
 
 {{ with .Get "url" }}
@@ -29,7 +29,7 @@ Example: {{/*
     {{ with $.Get "name" }}
         {{ $name := . }}
         <ul id="{{ $name }}" class="cs-hidden">
-        {{ $data := getJson $url }}
+        {{ $data := getJSON $url }}
         {{ range $data.items }}
             {{ $item := . }}
             <li data-thumb="{{ $item.thumb }}" data-src="{{ $item.full }}">


### PR DESCRIPTION
Many Hugo functions and variables have changed case since this last
worked, e.g. safeHtml to safeHTML)
Hugo now requires {{< >}} instead of {{% %}} around shortcodes that
output raw HTML
Fixes #3.